### PR TITLE
fix(version): bump build version to 0.0.20

### DIFF
--- a/jvm/version.properties
+++ b/jvm/version.properties
@@ -3,6 +3,6 @@ becknVersion=0.9.3
 # Used by shipkit auto version plugin.
 # Increment minor version in `version` whenever `becknVersion` changes.
 # e.g. If `version` is 0.0.* increment version to 0.1.* when `becknVersion` changes
-version=0.0.*
+version=0.0.20
 # Used by shipkit  auto version plugin
 tagPrefix=build-


### PR DESCRIPTION
The `bap-client` and `bap-protocol-helper` are dependent on protocol-dtos v9.3.20.

Please do keep bumping the patch version in the `jvm/version.properties` file whenever you tag a build, so that the `bap-client` and `bap-protocol-helper` can build without errors.